### PR TITLE
Uppercase alpha as list bullets

### DIFF
--- a/documentation.rem
+++ b/documentation.rem
@@ -137,12 +137,12 @@ reMarkable ("content", 0, 124, "../");
 This feature is experimental and likely to change in the future.
 
 Each option is a binary number that you combine together into a single number and supply to the `options` parameter. _
-Combine options using the logical OR “``||``” operator, e.g.:
+Combine options using the bitwise OR “``|``” operator, e.g.:
 
 ~~~ PHP ~~~>
 reMarkable (
 	"The quick¬brown fox.", 0, 124, "../",
-	REMARKABLE_NOXHTML || REMARKABLE_TABSPACE_4
+	REMARKABLE_NOXHTML | REMARKABLE_TABSPACE_4
 );
 <~~~
 

--- a/remarkable.php
+++ b/remarkable.php
@@ -141,8 +141,8 @@ function reMarkable (
 			(?:www\.)?						# ignore www
 			(							# $5 = friendly URL (no protocol)
 				([a-z0-9._%+-]+@[a-z0-9.-]+)?			# $6 = email address
-				(?(4)[a-z0-9.-]{2,}(?:\.[a-z]{2,4})+   |	# domain name (mandatory if protocol given)
-				 (?(1)|[a-z0-9.-]{2,}(?:\.[a-z]{2,4})+))	# domain name (mandatory if no description)
+				(?(4)[a-z0-9.-]{1,}(?:\.[a-z]{2,4})+   |	# domain name (mandatory if protocol given)
+				 (?(1)|[a-z0-9.-]{1,}(?:\.[a-z]{2,4})+))	# domain name (mandatory if no description)
 				(						# $7 = folders and filename, relative URL
 					(?(4)\/|(?(1)|\/))			# slash required after full domain
 					[\/a-z0-9_!~*\'().;?:@&=+$,%-]*		# folders and filename

--- a/remarkable.php
+++ b/remarkable.php
@@ -428,7 +428,7 @@ function reMarkable (
 	/* [5] blocks - lists / blockquotes
 	   ============================================================================================================== */
 	//see documentation (or read regex) for full list of supported bullet types. note that this has capturing groups
-	$bullet = '(?:([\x{2022}*+-])|(?-i:[a-z]\.|[ivxlcdm]+\.|#|(?:\d+\.){1,6}))(?: \(#([0-9a-z_-]+)\))?';
+	$bullet = '(?:([\x{2022}*+-])|(?-i:[a-zA-Z]\.|[ivxlcdm]+\.|#|(?:\d+\.){1,6}))(?: \(#([0-9a-z_-]+)\))?';
 	
 	//capture, convert and unindent lists and blockquotes, recursively: (I hope you’re fluent in regex)
 	do $source_text = preg_replace (array (

--- a/remarkable.php
+++ b/remarkable.php
@@ -222,7 +222,7 @@ function reMarkable (
 					//add deafult protocol if no link description and protocol was omitted
 					.(!$m[1][0] && !$m[4][0]
 					? (@$m[6][0] ? 'mailto:' : 'http://')
-					: ($m[4][0] == '//' ? 'http:' : '')).
+					: ($m[4][0] == '//' ? 'http:' : (@$m[6][0] ? 'mailto:' : ''))).
 					//encode URLs (`&amp;`)
 					preg_replace ('/&(?!amp;)/i', '&amp;', $m[3][0])
 				.'"'.

--- a/remarkable.php
+++ b/remarkable.php
@@ -48,7 +48,7 @@ function reMarkable (
 	$source_text = trim (rtrim (preg_replace ('/\r\n?/', "\n", $source_text)), "\n")."\n\n";
 	
 	//will we be using the X in XHTML?
-	$x = ($options && REMARKABLE_NOXHTML) ? '' : ' /';
+	$x = ($options & REMARKABLE_NOXHTML) ? '' : ' /';
 	
 	
 	/* list of mime-types for hyperlinks pointing directly to a file:

--- a/remarkable.php
+++ b/remarkable.php
@@ -428,7 +428,7 @@ function reMarkable (
 	/* [5] blocks - lists / blockquotes
 	   ============================================================================================================== */
 	//see documentation (or read regex) for full list of supported bullet types. note that this has capturing groups
-	$bullet = '(?:([\x{2022}*+-])|(?-i:[a-zA-Z]\.|[ivxlcdm]+\.|#|(?:\d+\.){1,6}))(?: \(#([0-9a-z_-]+)\))?';
+	$bullet = '(?:([\x{2022}*+-])|(?-i:[a-z]\.|[ivxlcdm]+\.|#|(?:\d+\.){1,6}))(?: \(#([0-9a-z_-]+)\))?';
 	
 	//capture, convert and unindent lists and blockquotes, recursively: (I hope you’re fluent in regex)
 	do $source_text = preg_replace (array (

--- a/remarkable.php
+++ b/remarkable.php
@@ -9,7 +9,7 @@
 */
 
 /* --- options ---------------------------------------------------------------------------------------------------------- */
-//combine these options using an OR `||` operand and supply to the options parameter
+//combine these options using an OR `|` operator and supply to the options parameter
 define ('REMARKABLE_NOXHTML',		1);	//output HTML “<br>” instead of XHTML (deafult) “<br />”
 define ('REMARKABLE_TABSPACE_2',	2);	//output tabs as spaces, 2 per tab
 define ('REMARKABLE_TABSPACE_4',	4);	//output tabs as spaces, 4 per tab. combine with above for 8 per tab
@@ -619,11 +619,11 @@ function reMarkable (
 	}
 	
 	//apply tab output preference
-	if ($options && (REMARKABLE_TABSPACE_2 || REMARKABLE_TABSPACE_4)) $source_text = preg_replace ('/^(\t+)/me', (
+	if ($options & (REMARKABLE_TABSPACE_2 | REMARKABLE_TABSPACE_4)) $source_text = preg_replace ('/^(\t+)/me', (
 		//8, 4, or 2 spaces?
 		'str_repeat("'.(
-			!($options xor (REMARKABLE_TABSPACE_2 || REMARKABLE_TABSPACE_4))
-			? '        ' : ($options && REMARKABLE_TABSPACE_4 ? '    ' : '  ')
+			!($options ^ (REMARKABLE_TABSPACE_2 | REMARKABLE_TABSPACE_4))
+			? '        ' : ($options & REMARKABLE_TABSPACE_4 ? '    ' : '  ')
 		).'",strlen("$1"))'
 	), $source_text);
 	

--- a/remarkable.php
+++ b/remarkable.php
@@ -196,7 +196,9 @@ function reMarkable (
 			//thumbnail syntax that generates “<a><img /></a>” which is detected later and split and indented
 			case 'IMG': /* ---------------------------------------------------------------------------------- */
 			//get the image size for width / height attributes on the img tag
-			$info = getimagesize ($base_path.$m[3][0]);
+			$info = ( (bool) strpos($m[3][0], '://') === FALSE)
+                ? getimagesize ($base_path.$m[3][0])
+                : getimagesize($m[3][0]);
 			$link = @$mimes[pathinfo ($m[4][0], PATHINFO_EXTENSION)];
 			//swap in the HTML
 			$source_text = substr_replace ($source_text,


### PR DESCRIPTION
Changed regex to support uppercase alpha characters as list
bullets as described in the documentation:

A.  Upper alpha
